### PR TITLE
distinguish between route not found and route get real error

### DIFF
--- a/pkg/hoster/hoster.go
+++ b/pkg/hoster/hoster.go
@@ -32,8 +32,8 @@ func GuessHoster(name string) (Hoster, error) {
 		return nil, errors.New("hoster not supported: " + name)
 	}
 
-	for _, host := range Hosters {
-		if host.OnThisHoster() {
+	for _, h = range Hosters {
+		if h.OnThisHoster() {
 			return h, nil
 		}
 	}


### PR DESCRIPTION
We should accept that a route does not yet exists, but fail if the
route get api call returns an error (except "not found", that is).