### PR TITLE
Suport multi-homed/multi-network/multi-interfaces instances

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,9 @@ var (
 	nomain   bool
 	accessk  string
 	secretk  string
+	iface    string
+	subnet   string
+	targetip string
 )
 
 func newCfiConfig() *config.CfiConfig {
@@ -40,6 +43,9 @@ func newCfiConfig() *config.CfiConfig {
 		Region:        viper.GetString("region"),
 		Zone:          viper.GetString("zone"),
 		NoMain:        viper.GetBool("ignore-main-table"),
+		Iface:         viper.GetString("interface"),
+		Subnet:        viper.GetString("subnet"),
+		TargetIP:      viper.GetString("target-ip"),
 		AwsAccesKeyID: viper.GetString("aws-access-key-id"),
 		AwsSecretKey:  viper.GetString("aws-secret-key"),
 	}
@@ -115,6 +121,15 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVarP(&nomain, "ignore-main-table", "m", false, "(AWS) ignore routes in main table")
 	bindPFlag("ignore-main-table", "ignore-main-table")
+
+	rootCmd.PersistentFlags().StringVarP(&iface, "interface", "f", "", "Network interface ID")
+	bindPFlag("interface", "interface")
+
+	rootCmd.PersistentFlags().StringVarP(&subnet, "subnet", "s", "", "Subnet ID")
+	bindPFlag("subnet", "subnet")
+
+	rootCmd.PersistentFlags().StringVarP(&targetip, "target-ip", "g", "", "Target private IP")
+	bindPFlag("target-ip", "target-ip")
 
 	rootCmd.PersistentFlags().StringVarP(&accessk, "aws-access-key-id", "a", "", "(AWS) access key Id")
 	bindPFlag("aws-access-key-id", "aws-access-key-id")

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,15 @@ type CfiConfig struct {
 	// Ignore tables associated with the main route table
 	NoMain bool
 
+	// Interface ID
+	Iface string
+
+	// Subnet ID
+	Subnet string
+
+	// Target private IP
+	TargetIP string
+
 	// AwsAccesKeyID (AWS only) is the acccess key to use (if we don't use an instance profile's role)
 	AwsAccesKeyID string
 


### PR DESCRIPTION
When the target instance has more than one "external" (attached
to the VPC) interface, we can now select the correct one if the
user provided either the interface name, the subnet name, or the
target interface's private IP.